### PR TITLE
add repo to tag

### DIFF
--- a/docker-entry
+++ b/docker-entry
@@ -13,9 +13,9 @@ cd $CHECK50_REPO
 echo "Checking out $CHECK50_COMMIT..."
 git checkout $CHECK50_COMMIT
 
-# Construct tag name
+# Construct tag name (note assumes system timezone is utc)
 echo "Constructing tag name..."
-TAG_NAME="$CHECK50_REPO:$CHECK50_BRANCH@$(date '+%Y%m%dT%H%M%S.%N%:z')"
+TAG_NAME="$CHECK50_REPO-$CHECK50_BRANCH@$(date '+%Y%m%dT%H%M%S.%NZ')"
 echo "Tag name is $TAG_NAME..."
 
 # Squash commit

--- a/docker-entry
+++ b/docker-entry
@@ -15,7 +15,7 @@ git checkout $CHECK50_COMMIT
 
 # Construct tag name
 echo "Constructing tag name..."
-TAG_NAME="$CHECK50_BRANCH@$(date '+%Y%m%dT%H%M%SZ')"
+TAG_NAME="$CHECK50_REPO:$CHECK50_BRANCH@$(date '+%Y%m%dT%H%M%SZ')"
 echo "Tag name is $TAG_NAME..."
 
 # Squash commit

--- a/docker-entry
+++ b/docker-entry
@@ -15,7 +15,7 @@ git checkout $CHECK50_COMMIT
 
 # Construct tag name
 echo "Constructing tag name..."
-TAG_NAME="$CHECK50_REPO:$CHECK50_BRANCH@$(date '+%Y%m%dT%H%M%S.%NZ')"
+TAG_NAME="$CHECK50_REPO:$CHECK50_BRANCH@$(date '+%Y%m%dT%H%M%S.%N%:z')"
 echo "Tag name is $TAG_NAME..."
 
 # Squash commit

--- a/docker-entry
+++ b/docker-entry
@@ -15,7 +15,7 @@ git checkout $CHECK50_COMMIT
 
 # Construct tag name
 echo "Constructing tag name..."
-TAG_NAME="$CHECK50_REPO:$CHECK50_BRANCH@$(date '+%Y%m%dT%H%M%SZ')"
+TAG_NAME="$CHECK50_REPO:$CHECK50_BRANCH@$(date '+%Y%m%dT%H%M%S.%NZ')"
 echo "Tag name is $TAG_NAME..."
 
 # Squash commit


### PR DESCRIPTION
Two students submitted exactly the same code at exactly the same time and as a result ended up with exactly the same tag hash. Adding the repo to the tag should fix this. To further decrease the likelihood of a collision (e.g. from the same student somehow commiting the same code in the same second), I've also added nanoseconds to the timestamp.

Edit: actually the students didn't commit at the same time (about a 20 second delta) but bot50 did  tag them at the exact same time.